### PR TITLE
feat(client): add button loading delay

### DIFF
--- a/packages/client/src/components/button/index.tsx
+++ b/packages/client/src/components/button/index.tsx
@@ -7,6 +7,7 @@ import { azure, raven, watermelon, white } from 'styles/variables'
 export type Status = 'danger' | 'default' | 'primary'
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  delay?: number
   isLoading?: boolean
   isOutlined?: boolean
   status?: Status
@@ -85,7 +86,7 @@ const Root = styled.button`
   }};
 `
 
-const Loading = styled.div`
+const Spinner = styled.div`
   animation: ${rotate} 1s ease-in-out infinite;
   height: ${rem(12)};
   margin: 0 auto;
@@ -111,15 +112,43 @@ const Loading = styled.div`
 
 const Button: React.FunctionComponent<Props> = ({
   children,
+  delay = 200,
   isLoading,
   isOutlined,
   status,
   ...rest
-}: Props) => (
-  <Root isLoading={isLoading} isOutlined={isOutlined} status={status} {...rest}>
-    {isLoading && <Loading isOutlined={isOutlined} status={status} />}
-    {children}
-  </Root>
-)
+}: Props) => {
+  const [isSpinnerVisible, setIsSpinnerVisible] = React.useState(false)
+
+  React.useEffect(() => {
+    if (isLoading) {
+      const timeout = setTimeout(() => setIsSpinnerVisible(true), delay)
+
+      return () => clearTimeout(timeout)
+    }
+
+    setIsSpinnerVisible(false)
+
+    return undefined
+  }, [delay, isLoading])
+
+  return (
+    <Root
+      isLoading={isSpinnerVisible}
+      isOutlined={isOutlined}
+      status={status}
+      {...rest}
+    >
+      {isSpinnerVisible && (
+        <Spinner
+          data-testid="spinner"
+          isOutlined={isOutlined}
+          status={status}
+        />
+      )}
+      {children}
+    </Root>
+  )
+}
 
 export default Button

--- a/packages/client/src/components/button/stories.tsx
+++ b/packages/client/src/components/button/stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { boolean, select, text } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
+import { boolean, number, select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
 import Button, { Status } from '.'
@@ -13,6 +13,7 @@ const options: Record<string, Status> = {
 
 storiesOf('Components|Button', module).addCentered('Default', () => (
   <Button
+    delay={number('Delay', 200)}
     isLoading={boolean('Is Loading', false)}
     isOutlined={boolean('Is Outlined', false)}
     onClick={action('On Click')}

--- a/packages/client/src/components/button/test.tsx
+++ b/packages/client/src/components/button/test.tsx
@@ -1,7 +1,19 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { act, render } from 'react-testing-library'
 
 import Button from '.'
+
+jest.useFakeTimers()
+
+test('should initialize the loading state once the provided delay (ms) has passed', () => {
+  const { queryByTestId } = render(<Button isLoading>child</Button>)
+
+  expect(queryByTestId('spinner')).not.toBeInTheDocument()
+
+  act(() => jest.runOnlyPendingTimers())
+
+  expect(queryByTestId('spinner')).toBeInTheDocument()
+})
 
 test('should render the default style correctly', () => {
   const { container } = render(<Button>child</Button>)


### PR DESCRIPTION
This PR adds a delay property to the button component that will postpone it's loading state

**Demo**

![kapture 2019-02-26 at 13 40 26](https://user-images.githubusercontent.com/450495/53448655-cb64c000-39cc-11e9-96fe-7bfd81bbc8e3.gif)
