### PR TITLE
feat: add radio component

### DIFF
--- a/packages/client/src/components/input-field/index.tsx
+++ b/packages/client/src/components/input-field/index.tsx
@@ -42,7 +42,7 @@ const InputField: React.FunctionComponent<Props> = ({
       </Label>
     )}
     <Input id={id} status={status} {...rest} />
-    {notice && <Notice status="failure">{notice}</Notice>}
+    {notice && <Notice variant="danger">{notice}</Notice>}
   </Root>
 )
 

--- a/packages/client/src/components/input-field/test.tsx
+++ b/packages/client/src/components/input-field/test.tsx
@@ -1,16 +1,20 @@
 import React from 'react'
+import { ThemeProvider } from 'styled-components'
 import { render } from 'react-testing-library'
 
+import { createTheme } from 'utilities/style'
 import InputField from '.'
 
 test('should render the provided label correctly', () => {
   const { getByLabelText } = render(
-    <InputField
-      id="41d1dd52-2e68-487a-bf61-b464c49a67f1"
-      data-testid="input-field"
-      isRequired={false}
-      label="label"
-    />
+    <ThemeProvider theme={createTheme()}>
+      <InputField
+        id="41d1dd52-2e68-487a-bf61-b464c49a67f1"
+        data-testid="input-field"
+        isRequired={false}
+        label="label"
+      />
+    </ThemeProvider>
   )
 
   expect(getByLabelText('label')).toHaveAttribute('data-testid', 'input-field')
@@ -18,7 +22,9 @@ test('should render the provided label correctly', () => {
 
 test('should render the provided notice correctly', () => {
   const { getByText } = render(
-    <InputField id="ac3cecd6-d704-4b2e-b3ef-bf8a54bd65d9" notice="notice" />
+    <ThemeProvider theme={createTheme()}>
+      <InputField id="ac3cecd6-d704-4b2e-b3ef-bf8a54bd65d9" notice="notice" />
+    </ThemeProvider>
   )
 
   expect(getByText('notice')).toBeInTheDocument()

--- a/packages/client/src/components/label/index.tsx
+++ b/packages/client/src/components/label/index.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { rem } from 'polished'
-
-import { heather } from 'styles/variables'
+import { em } from 'polished'
 
 interface Props extends React.LabelHTMLAttributes<HTMLLabelElement> {
   children: React.ReactNode
@@ -10,10 +8,14 @@ interface Props extends React.LabelHTMLAttributes<HTMLLabelElement> {
 }
 
 const Root = styled.label`
-  color: ${heather};
+  color: ${({ theme }) => theme.label.color};
   display: block;
-  font-size: ${rem(12)};
-  font-weight: 700;
+  font-size: ${({ theme }) => theme.label.fontSize};
+  font-weight: ${({ theme }) => theme.label.fontWeight};
+
+  :not(:last-child) {
+    margin-bottom: ${em(8)};
+  }
 `
 
 const Label: React.FunctionComponent<Props> = ({

--- a/packages/client/src/components/label/stories.tsx
+++ b/packages/client/src/components/label/stories.tsx
@@ -6,6 +6,6 @@ import Label from '.'
 
 storiesOf('Components|Label', module).addCentered('Default', () => (
   <Label isRequired={boolean('Is Required', false)}>
-    {text('Content', 'Title')}
+    {text('Content', 'Label')}
   </Label>
 ))

--- a/packages/client/src/components/label/test.tsx
+++ b/packages/client/src/components/label/test.tsx
@@ -1,19 +1,27 @@
 import React from 'react'
+import { ThemeProvider } from 'styled-components'
 import { render } from 'react-testing-library'
 
+import { createTheme } from 'utilities/style'
 import Label from '.'
 
 test('should not append the required symbol to the provided children', () => {
-  const { getByText } = render(<Label data-testid="label">child</Label>)
+  const { getByText } = render(
+    <ThemeProvider theme={createTheme()}>
+      <Label data-testid="label">child</Label>
+    </ThemeProvider>
+  )
 
   expect(getByText('child')).toHaveAttribute('data-testid', 'label')
 })
 
 test('should append the required symbol to the provided children', () => {
   const { getByText } = render(
-    <Label data-testid="label" isRequired>
-      child
-    </Label>
+    <ThemeProvider theme={createTheme()}>
+      <Label data-testid="label" isRequired>
+        child
+      </Label>
+    </ThemeProvider>
   )
 
   expect(getByText('child*')).toHaveAttribute('data-testid', 'label')

--- a/packages/client/src/components/notice/index.ts
+++ b/packages/client/src/components/notice/index.ts
@@ -1,24 +1,15 @@
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { rem } from 'polished'
 
-import { aquaMarine, raven, watermelon } from 'styles/variables'
-
-export type Status = 'default' | 'failure' | 'success'
-
 interface Props {
-  status?: Status
+  variant?: NoticeVariant
 }
 
-const statusColors: Record<Status, string> = {
-  default: raven,
-  failure: watermelon,
-  success: aquaMarine,
-}
-
-const Notice = styled.div`
-  color: ${({ status = 'default' }: Props) => statusColors[status]};
-  font-size: ${rem(12)};
-  font-weight: 500;
+const Notice = styled.p<Props>`
+  color: ${({ theme, variant = 'default' }) => theme.notice[variant]};
+  display: block;
+  font-size: ${({ theme }) => theme.notice.fontSize};
+  margin-top: ${rem(4)};
 `
 
 export default Notice

--- a/packages/client/src/components/notice/stories.tsx
+++ b/packages/client/src/components/notice/stories.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
+import { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
-import Notice, { Status } from '.'
+import Notice from '.'
 
-const options: Record<string, Status> = {
+const options: Record<string, NoticeVariant> = {
   Default: 'default',
-  Failure: 'failure',
+  Danger: 'danger',
   Success: 'success',
 }
 
 storiesOf('Components|Notice', module).addCentered('Default', () => (
-  <Notice status={select('Status', options, 'default')}>
+  <Notice variant={select('Variant', options, 'default')}>
     {text('Content', 'The user already exists')}
   </Notice>
 ))

--- a/packages/client/src/components/notice/test.tsx
+++ b/packages/client/src/components/notice/test.tsx
@@ -1,22 +1,36 @@
 import React from 'react'
+import { ThemeProvider } from 'styled-components'
 import { render } from 'react-testing-library'
 
+import { createTheme } from 'utilities/style'
 import Notice from '.'
 
-test('should render the default style correctly', () => {
-  const { container } = render(<Notice>child</Notice>)
+test('should render the default variant correctly', () => {
+  const { container } = render(
+    <ThemeProvider theme={createTheme()}>
+      <Notice>child</Notice>
+    </ThemeProvider>
+  )
 
   expect(container.firstChild).toMatchSnapshot()
 })
 
-test('should render the failure style correctly', () => {
-  const { container } = render(<Notice status="failure">child</Notice>)
+test('should render the danger variant correctly', () => {
+  const { container } = render(
+    <ThemeProvider theme={createTheme()}>
+      <Notice variant="danger">child</Notice>
+    </ThemeProvider>
+  )
 
   expect(container.firstChild).toMatchSnapshot()
 })
 
-test('should render the success style correctly', () => {
-  const { container } = render(<Notice status="success">child</Notice>)
+test('should render the success variant correctly', () => {
+  const { container } = render(
+    <ThemeProvider theme={createTheme()}>
+      <Notice variant="success">child</Notice>
+    </ThemeProvider>
+  )
 
   expect(container.firstChild).toMatchSnapshot()
 })

--- a/packages/client/src/components/notice/test.tsx.snap
+++ b/packages/client/src/components/notice/test.tsx.snap
@@ -1,43 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render the default style correctly 1`] = `
+exports[`should render the danger variant correctly 1`] = `
 .c0 {
-  color: #333;
+  color: #ff3860;
+  display: block;
   font-size: 0.75rem;
-  font-weight: 500;
+  margin-top: 0.25rem;
 }
 
-<div
+<p
   class="c0"
 >
   child
-</div>
+</p>
 `;
 
-exports[`should render the failure style correctly 1`] = `
+exports[`should render the default variant correctly 1`] = `
 .c0 {
-  color: #ed5357;
+  color: #4a4a4a;
+  display: block;
   font-size: 0.75rem;
-  font-weight: 500;
+  margin-top: 0.25rem;
 }
 
-<div
+<p
   class="c0"
 >
   child
-</div>
+</p>
 `;
 
-exports[`should render the success style correctly 1`] = `
+exports[`should render the success variant correctly 1`] = `
 .c0 {
-  color: #54dec3;
+  color: #23d160;
+  display: block;
   font-size: 0.75rem;
-  font-weight: 500;
+  margin-top: 0.25rem;
 }
 
-<div
+<p
   class="c0"
 >
   child
-</div>
+</p>
 `;

--- a/packages/client/src/components/radio/index.tsx
+++ b/packages/client/src/components/radio/index.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import styled from 'styled-components'
+import { em } from 'polished'
+
+interface Props
+  extends Exclude<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'checked' | 'disabled' | 'type'
+  > {
+  id: string
+  isChecked?: boolean
+  isDisabled?: boolean
+  label?: string
+}
+
+const Root = styled.div`
+  align-items: center;
+  display: inline-flex;
+
+  & + & {
+    margin-left: ${em(8)};
+  }
+`
+
+const Input = styled.input`
+  border-radius: 100%;
+  cursor: pointer;
+  height: 20px;
+  opacity: 0;
+  position: absolute;
+  width: 20px;
+
+  &:disabled,
+  fieldset:disabled & {
+    cursor: not-allowed;
+  }
+`
+
+const Toggle = styled.div`
+  align-items: center;
+  border-radius: 100%;
+  border: 2px solid ${({ theme }) => theme.radio.toggleColor};
+  display: flex;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+
+  ::before {
+    border-radius: 100%;
+    content: '';
+    height: 10px;
+    width: 10px;
+
+    input:checked ~ & {
+      background-color: ${({ theme }) => theme.radio.toggleCheckedColor};
+    }
+
+    input:checked:disabled ~ & {
+      background-color: ${({ theme }) => theme.radio.toggleDisabledColor};
+    }
+  }
+
+  input:checked ~ & {
+    border-color: ${({ theme }) => theme.radio.toggleCheckedColor};
+  }
+
+  input:disabled ~ & {
+    border-color: ${({ theme }) => theme.radio.toggleDisabledColor};
+  }
+`
+
+const Label = styled.label`
+  cursor: pointer;
+  display: inline-block;
+  line-height: 1.25;
+  margin-left: ${em(4)};
+
+  :hover {
+    color: ${({ theme }) => theme.radio.hoverColor};
+  }
+
+  input:disabled ~ &,
+  fieldset:disabled & {
+    color: ${({ theme }) => theme.radio.disabledColor};
+    cursor: not-allowed;
+  }
+`
+
+const Radio: React.FunctionComponent<Props> = ({
+  className,
+  id,
+  isChecked,
+  isDisabled,
+  label,
+  ...rest
+}: Props) => (
+  <Root className={className}>
+    <Input
+      id={id}
+      {...rest}
+      checked={isChecked}
+      disabled={isDisabled}
+      type="radio"
+    />
+    <Toggle />
+    <Label htmlFor={id}>{label}</Label>
+  </Root>
+)
+
+export default Radio

--- a/packages/client/src/components/radio/stories.tsx
+++ b/packages/client/src/components/radio/stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { boolean, text } from '@storybook/addon-knobs'
+import { storiesOf } from '@storybook/react'
+
+import Radio from '.'
+
+storiesOf('Components|Radio ', module).addCentered('Default', () => (
+  <React.Fragment>
+    <Radio
+      id="f524dabc-13b6-4fa2-b633-2a852b28b39a"
+      isDisabled={boolean('Is Disabled (Radio A)', false)}
+      label={text('Label (Radio A)', 'Radio A')}
+      name="radio"
+    />
+    <Radio
+      id="53394530-d091-4a93-be90-351df19d704c"
+      isDisabled={boolean('Is Disabled (Radio B)', false)}
+      label={text('Label (Radio B)', 'Radio B')}
+      name="radio"
+    />
+  </React.Fragment>
+))

--- a/packages/client/src/routes/recover/index.tsx
+++ b/packages/client/src/routes/recover/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { Form as BaseForm, Formik } from 'formik'
 import { Link as BaseLink, RouteComponentProps } from '@reach/router'
 import { Mutation, Query } from 'react-apollo'
@@ -7,7 +7,7 @@ import { object, string } from 'yup'
 import { rem } from 'polished'
 
 import BaseButton from 'components/button'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import ControlledInputField from 'components/controlled-input-field'
 import { centered, link } from 'styles/mixins'
 import { renderLoadingIf } from 'utilities/loading'
@@ -66,7 +66,7 @@ const Recover: React.FunctionComponent<RouteComponentProps> = ({
   ...rest
 }: RouteComponentProps) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <Root data-testid="recover" {...rest}>
@@ -77,17 +77,17 @@ const Recover: React.FunctionComponent<RouteComponentProps> = ({
             onCompleted={({ response }) => {
               if (response.error) {
                 setNotice(response.error.message)
-                setStatus('failure')
+                setVariant('danger')
               } else {
                 setNotice('A verification email has been sent')
-                setStatus('success')
+                setVariant('success')
               }
             }}
           >
             {(onSubmit, result) =>
               renderLoadingIf(loading, () => (
                 <React.Fragment>
-                  {notice && <Notice status={status}>{notice}</Notice>}
+                  {notice && <Notice variant={variant}>{notice}</Notice>}
                   <Formik<Values>
                     initialValues={{ email: data.user ? data.user.email : '' }}
                     onSubmit={variables => onSubmit({ variables })}

--- a/packages/client/src/routes/register/index.tsx
+++ b/packages/client/src/routes/register/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { Form as BaseForm, Formik } from 'formik'
 import { Mutation } from 'react-apollo'
 import { RouteComponentProps } from '@reach/router'
@@ -7,7 +7,7 @@ import { object, ref, string } from 'yup'
 import { rem } from 'polished'
 
 import BaseButton from 'components/button'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import BaseSubnavbar from 'components/subnavbar'
 import ControlledInputField from 'components/controlled-input-field'
 import { centered } from 'styles/mixins'
@@ -85,7 +85,7 @@ const Register: React.FunctionComponent<RouteComponentProps> = ({
   ...rest
 }: RouteComponentProps) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <Mutation<RegisterMutationData, RegisterMutationVariables>
@@ -93,17 +93,17 @@ const Register: React.FunctionComponent<RouteComponentProps> = ({
       onCompleted={({ response }) => {
         if (response.error) {
           setNotice(response.error.message)
-          setStatus('failure')
+          setVariant('danger')
         } else {
           setNotice('A verification email has been sent')
-          setStatus('success')
+          setVariant('success')
         }
       }}
     >
       {(onSubmit, { loading }) => (
         <Root data-testid="register" {...rest}>
           <Subnavbar items={items} />
-          {notice && <Notice status={status}>{notice}</Notice>}
+          {notice && <Notice variant={variant}>{notice}</Notice>}
           <Formik<Values>
             initialValues={initialValues}
             onSubmit={input => onSubmit({ variables: { input } })}

--- a/packages/client/src/routes/settings/confirm-two-factor-auth-form.tsx
+++ b/packages/client/src/routes/settings/confirm-two-factor-auth-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { ApolloConsumer, Mutation } from 'react-apollo'
 import { Form as BaseForm, Formik } from 'formik'
 import { object, string } from 'yup'
@@ -7,7 +7,7 @@ import { rem } from 'polished'
 
 import BaseButton from 'components/button'
 import BaseControlledInputField from 'components/controlled-input-field'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import {
   ConfirmTwoFactorAuthMutationData,
   ConfirmTwoFactorAuthMutationVariables,
@@ -56,7 +56,7 @@ const ConfirmTwoFactorAuthForm: React.FunctionComponent<Props> = ({
   ...rest
 }: Props) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <ApolloConsumer>
@@ -73,7 +73,7 @@ const ConfirmTwoFactorAuthForm: React.FunctionComponent<Props> = ({
 
             if (response.error) {
               setNotice(response.error.message)
-              setStatus('failure')
+              setVariant('danger')
             } else if (onCompleted) {
               onCompleted()
             }
@@ -87,7 +87,7 @@ const ConfirmTwoFactorAuthForm: React.FunctionComponent<Props> = ({
             >
               {() => (
                 <React.Fragment>
-                  {notice && <Notice status={status}>{notice}</Notice>}
+                  {notice && <Notice variant={variant}>{notice}</Notice>}
                   <Form {...rest} id={formId} noValidate>
                     <ControlledInputField
                       id={`${formId}-token`}

--- a/packages/client/src/routes/settings/disable-two-factor-auth-form.tsx
+++ b/packages/client/src/routes/settings/disable-two-factor-auth-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { Form as BaseForm, Formik } from 'formik'
 import { Mutation } from 'react-apollo'
 import { User } from '@fintruth-sdk/shared'
@@ -8,7 +8,7 @@ import { rem } from 'polished'
 
 import BaseButton from 'components/button'
 import BaseControlledInputField from 'components/controlled-input-field'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import {
   DisableTwoFactorAuthMutationData,
   DisableTwoFactorAuthMutationVariables,
@@ -59,7 +59,7 @@ const DisableTwoFactorAuthForm: React.FunctionComponent<Props> = ({
   ...rest
 }: Props) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <Mutation<
@@ -70,7 +70,7 @@ const DisableTwoFactorAuthForm: React.FunctionComponent<Props> = ({
       onCompleted={({ response }) => {
         if (response.error) {
           setNotice(response.error.message)
-          setStatus('failure')
+          setVariant('danger')
         } else if (onCompleted) {
           onCompleted()
         }
@@ -92,7 +92,7 @@ const DisableTwoFactorAuthForm: React.FunctionComponent<Props> = ({
         >
           {() => (
             <React.Fragment>
-              {notice && <Notice status={status}>{notice}</Notice>}
+              {notice && <Notice variant={variant}>{notice}</Notice>}
               <Form {...rest} id={formId} noValidate>
                 <ControlledInputField
                   id={`${formId}-token`}

--- a/packages/client/src/routes/settings/update-email-form.tsx
+++ b/packages/client/src/routes/settings/update-email-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { ApolloConsumer, Mutation } from 'react-apollo'
 import { Form as BaseForm, Formik } from 'formik'
 import { User } from '@fintruth-sdk/shared'
@@ -7,7 +7,7 @@ import { object, string } from 'yup'
 
 import BaseButton from 'components/button'
 import BaseControlledInputField from 'components/controlled-input-field'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import {
   UpdateEmailMutationData,
   UpdateEmailMutationVariables,
@@ -55,7 +55,7 @@ const UpdateEmailForm: React.FunctionComponent<Props> = ({
   ...rest
 }: Props) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <ApolloConsumer>
@@ -69,10 +69,10 @@ const UpdateEmailForm: React.FunctionComponent<Props> = ({
 
             if (response.error) {
               setNotice(response.error.message)
-              setStatus('failure')
+              setVariant('danger')
             } else if (response.user) {
               setNotice('Your email address was successfully updated')
-              setStatus('success')
+              setVariant('success')
             }
           }}
         >
@@ -84,7 +84,7 @@ const UpdateEmailForm: React.FunctionComponent<Props> = ({
             >
               {() => (
                 <React.Fragment>
-                  {notice && <Notice status={status}>{notice}</Notice>}
+                  {notice && <Notice variant={variant}>{notice}</Notice>}
                   <Form {...rest} id={formId} noValidate>
                     <ControlledInputField
                       id={`${formId}-newEmail`}

--- a/packages/client/src/routes/settings/update-password-form.tsx
+++ b/packages/client/src/routes/settings/update-password-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { ApolloConsumer, Mutation } from 'react-apollo'
 import { Form as BaseForm, Formik } from 'formik'
 import { Link as BaseLink } from '@reach/router'
@@ -8,7 +8,7 @@ import { rem } from 'polished'
 
 import BaseButton from 'components/button'
 import BaseControlledInputField from 'components/controlled-input-field'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import { link } from 'styles/mixins'
 import {
   UpdatePasswordMutationData,
@@ -65,7 +65,7 @@ const formId = 'update-password__Form'
 
 const UpdatePasswordForm: React.FunctionComponent = ({ ...rest }) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <ApolloConsumer>
@@ -79,10 +79,10 @@ const UpdatePasswordForm: React.FunctionComponent = ({ ...rest }) => {
 
             if (response.error) {
               setNotice(response.error.message)
-              setStatus('failure')
+              setVariant('danger')
             } else {
               setNotice('Your password was successfully updated')
-              setStatus('success')
+              setVariant('success')
             }
           }}
         >
@@ -94,7 +94,7 @@ const UpdatePasswordForm: React.FunctionComponent = ({ ...rest }) => {
             >
               {() => (
                 <React.Fragment>
-                  {notice && <Notice status={status}>{notice}</Notice>}
+                  {notice && <Notice variant={variant}>{notice}</Notice>}
                   <Form {...rest} id={formId} noValidate>
                     <ControlledInputField
                       id={`${formId}-password`}

--- a/packages/client/src/routes/settings/update-profile-form.tsx
+++ b/packages/client/src/routes/settings/update-profile-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { Form as BaseForm, Formik } from 'formik'
 import { Mutation } from 'react-apollo'
 import { User } from '@fintruth-sdk/shared'
@@ -7,7 +7,7 @@ import { object, string } from 'yup'
 
 import BaseButton from 'components/button'
 import BaseControlledInputField from 'components/controlled-input-field'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import {
   UpdateProfileMutationData,
   UpdateProfileMutationVariables,
@@ -53,7 +53,7 @@ const UpdateProfileForm: React.FunctionComponent<Props> = ({
   ...rest
 }: Props) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <Mutation<UpdateProfileMutationData, UpdateProfileMutationVariables>
@@ -61,10 +61,10 @@ const UpdateProfileForm: React.FunctionComponent<Props> = ({
       onCompleted={({ response }) => {
         if (response.error) {
           setNotice(response.error.message)
-          setStatus('failure')
+          setVariant('danger')
         } else if (response.profile) {
           setNotice('Your profile information was successfully updated')
-          setStatus('success')
+          setVariant('success')
         }
       }}
       update={(cache, { data = { response: { profile: null } } }) =>
@@ -87,7 +87,7 @@ const UpdateProfileForm: React.FunctionComponent<Props> = ({
         >
           {() => (
             <React.Fragment>
-              {notice && <Notice status={status}>{notice}</Notice>}
+              {notice && <Notice variant={variant}>{notice}</Notice>}
               <Form {...rest} id={formId} noValidate>
                 <ControlledInputField
                   id={`${formId}-firstName`}

--- a/packages/client/src/routes/sign-in/sign-in-form.tsx
+++ b/packages/client/src/routes/sign-in/sign-in-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { ApolloConsumer, Mutation } from 'react-apollo'
 import { Form as BaseForm, Formik } from 'formik'
 import { Link as BaseLink } from '@reach/router'
@@ -8,7 +8,7 @@ import { object, string } from 'yup'
 import { rem } from 'polished'
 
 import BaseButton from 'components/button'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import BaseSubnavbar from 'components/subnavbar'
 import ControlledInputField from 'components/controlled-input-field'
 import { link } from 'styles/mixins'
@@ -74,7 +74,7 @@ const SignInForm: React.FunctionComponent<Props> = ({
   ...rest
 }: Props) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <ApolloConsumer>
@@ -86,7 +86,7 @@ const SignInForm: React.FunctionComponent<Props> = ({
 
             if (response.error) {
               setNotice(response.error.message)
-              setStatus('failure')
+              setVariant('danger')
             } else if (response.user) {
               resolveNextView(response.user)
             }
@@ -95,7 +95,7 @@ const SignInForm: React.FunctionComponent<Props> = ({
           {(onSubmit, { loading }) => (
             <React.Fragment>
               <Subnavbar items={items} />
-              {notice && <Notice status={status}>{notice}</Notice>}
+              {notice && <Notice variant={variant}>{notice}</Notice>}
               <Formik<Values>
                 initialValues={initialValues}
                 onSubmit={variables => {

--- a/packages/client/src/routes/sign-in/sign-in-two-factor-auth-form.tsx
+++ b/packages/client/src/routes/sign-in/sign-in-two-factor-auth-form.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { NoticeVariant } from 'styled-components' // eslint-disable-line import/named
 import { ApolloConsumer, Mutation } from 'react-apollo'
 import { Form as BaseForm, Formik } from 'formik'
 import { User } from '@fintruth-sdk/shared'
 import { object, string } from 'yup'
 
 import BaseButton from 'components/button'
-import BaseNotice, { Status } from 'components/notice'
+import BaseNotice from 'components/notice'
 import ControlledInputField from 'components/controlled-input-field'
 import {
   SignInTwoFactorAuthMutationData,
@@ -55,7 +55,7 @@ const SignInTwoFactorAuthForm: React.FunctionComponent<Props> = ({
   ...rest
 }: Props) => {
   const [notice, setNotice] = React.useState<null | string>(null)
-  const [status, setStatus] = React.useState<Status>('success')
+  const [variant, setVariant] = React.useState<NoticeVariant>('success')
 
   return (
     <ApolloConsumer>
@@ -70,7 +70,7 @@ const SignInTwoFactorAuthForm: React.FunctionComponent<Props> = ({
 
             if (response.error) {
               setNotice(response.error.message)
-              setStatus('failure')
+              setVariant('danger')
             } else if (response.user) {
               resolveNextView(response.user)
             }
@@ -78,7 +78,7 @@ const SignInTwoFactorAuthForm: React.FunctionComponent<Props> = ({
         >
           {(onSubmit, { loading }) => (
             <React.Fragment>
-              {notice && <Notice status={status}>{notice}</Notice>}
+              {notice && <Notice variant={variant}>{notice}</Notice>}
               <Formik<Values>
                 initialValues={initialValues}
                 onSubmit={variables =>

--- a/packages/client/src/utilities/style.ts
+++ b/packages/client/src/utilities/style.ts
@@ -1,23 +1,8 @@
-import {
-  Body, // eslint-disable-line import/named
-  Code, // eslint-disable-line import/named
-  DefaultTheme, // eslint-disable-line import/named
-  Hr, // eslint-disable-line import/named
-  Pre, // eslint-disable-line import/named
-  Html, // eslint-disable-line import/named
-  Strong, // eslint-disable-line import/named
-  Variables, // eslint-disable-line import/named
-} from 'styled-components'
-import { em, hsl, hsla, readableColor, rem } from 'polished'
+import { DefaultTheme } from 'styled-components' // eslint-disable-line import/named
+import { em, hsl, hsla, readableColor, rem, transparentize } from 'polished'
 
-export interface PartialDefaultTheme extends Partial<Variables> {
-  body?: Partial<Body>
-  code?: Partial<Code>
-  hr?: Partial<Hr>
-  html?: Partial<Html>
-  pre?: Partial<Pre>
-  strong?: Partial<Strong>
-}
+type PartialDefaultTheme = RecursivePartial<DefaultTheme>
+type RecursivePartial<T> = { [P in keyof T]?: RecursivePartial<T[P]> }
 
 export const createTheme = ({
   grayDarker = hsl(0, 0, 0.21),
@@ -52,7 +37,12 @@ export const createTheme = ({
   blueContrast = readableColor(blue, lightContrast, darkContrast),
 
   textColor = grayDark,
+  textLightColor = gray,
   textStrongColor = grayDarker,
+
+  inputHoverColor = grayDarker,
+
+  inputDisabledColor = textLightColor,
 
   gap = 64,
 
@@ -68,7 +58,10 @@ export const createTheme = ({
   code = {},
   hr = {},
   html = {},
+  label = {},
+  notice = {},
   pre = {},
+  radio = {},
   strong = {},
 
   ...rest
@@ -145,9 +138,18 @@ export const createTheme = ({
   // Text Colors
   textColor,
   textColorContrast: readableColor(textColor, lightContrast, darkContrast),
-  textLightColor: gray,
+  textLightColor,
   textStrongColor,
   textSelectionColor: hsl(213, 0.92, 0.85),
+
+  // Input Colors
+  inputHoverColor,
+  inputHoverBorderColor: grayLight,
+
+  inputDisabledColor,
+  inputDisabledBackgroundColor: backgroundColor,
+  inputDisabledBorderColor: backgroundColor,
+  inputDisabledPlaceholderColor: transparentize(0.7, inputDisabledColor),
 
   // Responsiveness
   gap,
@@ -189,7 +191,7 @@ export const createTheme = ({
 
     // Typography
     fontFamily: fontFamilyCode,
-    fontSize: `${em(14)}`,
+    fontSize: em(14),
     fontWeight: 400,
 
     ...code,
@@ -211,7 +213,7 @@ export const createTheme = ({
     backgroundColor: white,
 
     // Typography
-    fontSize: `${em(16)}`,
+    fontSize: em(16),
     textRendering,
 
     // Miscellaneous
@@ -221,12 +223,47 @@ export const createTheme = ({
     ...html,
   },
 
+  label: {
+    // Colors
+    color: grayDarker,
+
+    // Typography
+    fontSize: rem(16),
+    fontWeight: 700,
+
+    ...label,
+  },
+
+  notice: {
+    // Colors
+    danger,
+    default: textColor,
+    success,
+
+    // Typography
+    fontSize: rem(12),
+
+    ...notice,
+  },
+
   pre: {
     // Colors
     backgroundColor,
     color: textColor,
 
     ...pre,
+  },
+
+  radio: {
+    // Colors
+    disabledColor: inputDisabledColor,
+    hoverColor: inputHoverColor,
+
+    toggleCheckedColor: blue,
+    toggleColor: textColor,
+    toggleDisabledColor: inputDisabledColor,
+
+    ...radio,
   },
 
   strong: {

--- a/packages/client/types/styled-components/index.d.ts
+++ b/packages/client/types/styled-components/index.d.ts
@@ -1,14 +1,16 @@
 import 'styled-components'
 
 declare module 'styled-components' {
-  export interface Body {
+  export type NoticeVariant = 'danger' | 'default' | 'success'
+
+  interface Body {
     color: string
     fontFamily: string
     fontWeight: number
     lineHeight: number
   }
 
-  export interface Code {
+  interface Code {
     backgroundColor: string
     color: string
     fontFamily: string
@@ -22,17 +24,20 @@ declare module 'styled-components' {
     code: Code
     hr: Hr
     html: Html
+    label: Label
+    notice: Notice
     pre: Pre
+    radio: Radio
     strong: Strong
   }
 
-  export interface Hr {
+  interface Hr {
     backgroundColor: string
     height: string
     margin: string
   }
 
-  export interface Html {
+  interface Html {
     backgroundColor: string
     fontSize: string
     overflowX: string
@@ -40,17 +45,35 @@ declare module 'styled-components' {
     textRendering: string
   }
 
-  export interface Pre {
+  interface Label {
+    color: string
+    fontSize: string
+    fontWeight: number
+  }
+
+  interface Notice extends Record<NoticeVariant, string> {
+    fontSize: string
+  }
+
+  interface Pre {
     backgroundColor: string
     color: string
   }
 
-  export interface Strong {
+  interface Radio {
+    disabledColor: string
+    hoverColor: string
+    toggleCheckedColor: string
+    toggleColor: string
+    toggleDisabledColor: string
+  }
+
+  interface Strong {
     color: string
     fontWeight: number
   }
 
-  export interface Variables {
+  interface Variables {
     backgroundColor: string
     black: string
     blackBis: string
@@ -79,6 +102,12 @@ declare module 'styled-components' {
     greenContrast: string
     info: string
     infoContrast: string
+    inputDisabledBackgroundColor: string
+    inputDisabledBorderColor: string
+    inputDisabledColor: string
+    inputDisabledPlaceholderColor: string
+    inputHoverBorderColor: string
+    inputHoverColor: string
     lightContrast: string
     linkActiveBorderColor: string
     linkActiveColor: string


### PR DESCRIPTION
This PR adds a `radio` component

In addition to adding a `radio` component, this PR also refactors the `notice` and `label` components to use the global theme

**Demo**

![Kapture 2019-04-10 at 23 39 54](https://user-images.githubusercontent.com/450495/55936142-4d5e2080-5bea-11e9-9a3a-46e0215985b1.gif)
