### PR TITLE
chore(client): remove unused eslint disable directives

### DIFF
--- a/packages/client/scripts/lib/webpack-hot-dev-client.js
+++ b/packages/client/scripts/lib/webpack-hot-dev-client.js
@@ -10,7 +10,6 @@ import {
 } from 'react-error-overlay'
 
 setEditorHandler(errorLocation =>
-  // eslint-disable-next-line no-undef
   fetch(
     `${launchEditorEndpoint}?fileName=${encodeURIComponent(
       errorLocation.fileName

--- a/packages/client/types/assets/index.d.ts
+++ b/packages/client/types/assets/index.d.ts
@@ -1,31 +1,31 @@
 declare module '*.bmp' {
   const src: string
 
-  export default src // eslint-disable-line import/export
+  export default src
 }
 
 declare module '*.gif' {
   const src: string
 
-  export default src // eslint-disable-line import/export
+  export default src
 }
 
 declare module '*.jpeg' {
   const src: string
 
-  export default src // eslint-disable-line import/export
+  export default src
 }
 
 declare module '*.jpg' {
   const src: string
 
-  export default src // eslint-disable-line import/export
+  export default src
 }
 
 declare module '*.png' {
   const src: string
 
-  export default src // eslint-disable-line import/export
+  export default src
 }
 
 declare module '*.svg' {
@@ -33,11 +33,11 @@ declare module '*.svg' {
 
   const src: React.FunctionComponent<React.SVGProps<SVGSVGElement>>
 
-  export default src // eslint-disable-line import/export
+  export default src
 }
 
 declare module '*.webp' {
   const src: string
 
-  export default src // eslint-disable-line import/export
+  export default src
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,7 @@
     "@fintruth-sdk/shared": "^0.1.0",
     "@fintruth-sdk/validation": "^0.1.0",
     "apollo-server-express": "^2.5.0",
-    "aws-sdk": "^2.450.0",
+    "aws-sdk": "^2.451.0",
     "base64url": "^3.0.1",
     "bcrypt": "^3.0.6",
     "compression": "^1.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2958,9 +2958,9 @@
     "@types/react" "*"
 
 "@types/react-native@*":
-  version "0.57.52"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.57.52.tgz#64f80498fbbe07884a08f77fd6fc387f489128e9"
-  integrity sha512-hbNlGvXZRHtz6eXBIzJXmUv7yTRNGsmuJ8DsYIgFkXRbth+AvoLsayPv0tPZr82/QTc4Q0WeCGpUb5Kovoof9A==
+  version "0.57.53"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.57.53.tgz#f54a1886c8de1bf4b54bd5f463d5d2e7cf3a7634"
+  integrity sha512-dBcehLQmES4gQxZAd4XifbaQA9cTtFIjDsIcYRIy2SG6aoQsqQjZmC2a/Nv2orvG8qR9pLgoO3GlJS2/lj5jAA==
   dependencies:
     "@types/prop-types" "*"
     "@types/react" "*"
@@ -4066,10 +4066,10 @@ autoprefixer@^9.4.7, autoprefixer@^9.5.1:
     postcss "^7.0.14"
     postcss-value-parser "^3.3.1"
 
-aws-sdk@^2.450.0:
-  version "2.450.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.450.0.tgz#5467484d7a08647d744229692bad96a03289e243"
-  integrity sha512-u15X4okLGJaiWTtDGgRfw5iHt1OHRQVji5/8A/1P59jWLmfc2Dm0csJ5y3HnbG1kYoauVLohm5sB5SpNyTkaxA==
+aws-sdk@^2.451.0:
+  version "2.451.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.451.0.tgz#d2c0e92dc0d35276063d8030a668bc4a5a94ea52"
+  integrity sha512-ruVK/fnUFHumSgcqVkJTHLS9eWXc8lf14ZW2G6RVR0baj2MMNDS5gxInuy8GM24Exe0GfnDFk6PnPiSuQs4AVQ==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -6148,9 +6148,9 @@ css-select@^2.0.0:
     nth-check "^1.0.2"
 
 css-to-react-native@^2.2.2:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.0.tgz#bf80d24ec4a08e430306ef429c0586e6ed5485f7"
-  integrity sha512-IhR7bNIrCFwbJbKZOAjNDZdwpsbjTN6f1agXeELHDqg1wHPA8c2QLruttKOW7hgMGetkfraRJCIEMrptifBfVw==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.1.tgz#cf0f61e0514846e2d4dc188b0886e29d8bef64a2"
+  integrity sha512-yO+oEx1Lf+hDKasqQRVrAvzMCz825Huh1VMlEEDlRWyAhFb/FWb6I0KpEF1PkyKQ7NEdcx9d5M2ZEWgJAsgPvQ==
   dependencies:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"


### PR DESCRIPTION
This PR removes unused ESLint disable directives from the `client` package