### PR TITLE
bug(client): revert formik version

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -50,7 +50,7 @@
     "core-js": "^3.1.2",
     "cors": "^2.8.5",
     "express": "^4.17.0",
-    "formik": "2.0.1-rc.0",
+    "formik": "2.0.1-alpha.2",
     "graphql": "^14.3.0",
     "history": "^4.9.0",
     "node-fetch": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8114,13 +8114,13 @@ format@^0.2.2:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-formik@2.0.1-rc.0:
-  version "2.0.1-rc.0"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.0.1-rc.0.tgz#02a1cf3616654578a25628d62e0dbaac4a9b2180"
-  integrity sha512-8v/CAODLAASE1Im/xx+UpbB4cP+VWEfCziMTrFnCZLvw7oqnCtY/uSeT3r33LWPsoEbhOj9ZZNHTzfehlR2kNQ==
+formik@2.0.1-alpha.2:
+  version "2.0.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.0.1-alpha.2.tgz#6751741d7ae2532b2a8ab683d074b52d9e4e3173"
+  integrity sha512-B6gDeIpAb1lQ6ytsCsK/UkvhCN7NGU4DW4aP/W280m2Fx2urk5FwotX3+xAsg9YpKLEHRBoesdpgyHJLDKhHKg==
   dependencies:
     deepmerge "^2.1.1"
-    hoist-non-react-statics "^3.3.0"
+    hoist-non-react-statics "^3.2.1"
     lodash "^4.17.11"
     lodash-es "^4.17.11"
     react-fast-compare "^2.0.1"
@@ -8880,7 +8880,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==


### PR DESCRIPTION
Reverts the Formik dependency of the client package to version: `2.0.1-alpha.2`. [Newer versions of the Formik dependency break the use of the `enableReinitialize` property.](https://github.com/jaredpalmer/formik/issues/1528)