### PR TITLE
feat(client): add loading state to the call-to-action sub-component

### DIFF
--- a/packages/client/src/components/file-field/stories.tsx
+++ b/packages/client/src/components/file-field/stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { boolean, select, text } from '@storybook/addon-knobs'
+import { boolean, number, select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { Formik } from 'formik'
 import React from 'react'
@@ -54,6 +54,8 @@ storiesOf('Components|File Field', module)
         name="file"
       >
         <FileFieldCallToAction
+          delay={number('delay', 200)}
+          isLoading={boolean('isLoading', false)}
           variant={select<Variant | ''>('variant', variants, '') || undefined}
         >
           <FileFieldIcon />


### PR DESCRIPTION
Adds a loading state to the `CallToAction` sub-component of the `FileField` component

## Demo

![Kapture 2019-09-18 at 14 46 01](https://user-images.githubusercontent.com/450495/65188353-130f6f80-da23-11e9-8cc2-4949ad70a8a6.gif)
